### PR TITLE
Add pylint to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Run pylint
+      # You may pin to the exact commit or the version.
+      # uses: gabriel-milan/action-pylint@5a2e0c4a6af3a7fac3c45e724b96d45f2a7a4352
+      uses: gabriel-milan/action-pylint@v1
+      with:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}} # GitHub token
+          path: "./*.py" # Glob pattern for files to lint
+          fail: true # Fail the action if pylint errors are found
+          pr-message: true # Send a PR message if pylint errors are found
     - name: Build docker image
       run: make docker-build
     - name: Run tests


### PR DESCRIPTION
Make it so that the CI runs pylint. Uses the Pylint action from github marketplace.